### PR TITLE
fix: only init TB once

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -421,7 +421,9 @@ module.exports = NodeHelper.create({
   socketNotificationReceived: function (notification, payload) {
     switch(notification) {
       case 'INIT':
-        this.initialize(payload)
+        if (this.TB === null) {
+          this.initialize(payload)
+        }
         break;
       case 'REPLY':
       case 'SAY':


### PR DESCRIPTION
When running multiple instances of the **UI**, you usually get an error like this:

```
1|mm  | [TELBOT] Error 409 Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
```

This is due to the fact, that each time the module is startet, the bot is initialized, even if it has been initialized by the module of another UI instance before.

This change prevents an initialization if the bot is already created.