### PR TITLE
Add support for RPM based Linux systems

### DIFF
--- a/installer/preinstall.sh
+++ b/installer/preinstall.sh
@@ -52,9 +52,11 @@ if  [ "$platform" == "osx" ]; then
 else
   Installer_success "OS Detected: $OSTYPE ($os_name $os_version $arch)"
   dependencies=(scrot)
-  Installer_info "Checking all dependencies..."
-  Installer_check_dependencies
-  Installer_success "All Dependencies needed are installed !"
+  [ "${__NO_DEP_CHECK__}" ] || {
+    Installer_info "Checking all dependencies..."
+    Installer_check_dependencies
+    Installer_success "All Dependencies needed are installed !"
+  }
 fi
 
 echo

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -39,6 +39,18 @@ Installer_checkOS () {
     *)        Installer_error "$OSTYPE is not a supported platform"
               exit 0;;
   esac
+
+  # Check if this is a Debian or RPM based system
+  debian=
+  have_apt=`type -p apt-get`
+  have_dpkg=`type -p dpkg`
+  have_dnf=`type -p dnf`
+  have_yum=`type -p yum`
+  [ -f /etc/os-release ] && {
+    id_like="$(cat /etc/os-release | grep ^ID_LIKE= | cut -f2 -d=)"
+  }
+  [ "${id_like}" == "debian" ] && debian=1
+  [ "${debian}" ] || [ -f /etc/debian_version ] && debian=1
 }
 
 # check if all dependencies are installed
@@ -66,25 +78,6 @@ Installer_check_dependencies () {
     Installer_warning "Please logout and login for new group permissions to take effect, then restart npm install"
     exit
   fi
-}
-
-# check the version of GCC and downgrade it if it's not 7
-Installer_check_gcc7 () {
-	Installer_debug "gcc: $Installer_gcc"
-	Installer_debug "gcc revision: $Installer_gcc_rev"
-	Installer_debug "gcc version: $Installer_gcc_version"
-	if [[ "$Installer_gcc_version" != "7" ]]; then
-		Installer_debug "Forced script to reconize as GCC 8"
-		Installer_warning "You are using GCC $Installer_gcc_version, this is not compatible with this program."
-		Installer_warning "You have to downgrade to GCC 7."
-		Installer_yesno "Do you want to make changes ?" || exit 1
-		Installer_info "Installing GCC 7..."
-		sudo apt-get install gcc-7 || exit 1
-		Installer_success "GCC 7 installed"
-		Installer_info "Making GCC 7 by default..."
-		sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 || exit 1
-		sudo update-alternatives --config gcc || exit 1
-	fi
 }
 
 # Do electron rebuild
@@ -195,36 +188,123 @@ Installer_log () {
   exec > >(tee >(Installer_add_timestamps >> installer.log)) 2>&1
 }
 
-# display gcc version
-Installer_gcc="$(gcc --version | grep gcc)"
-Installer_gcc_rev="$(echo "${Installer_gcc#g*) }")"
-Installer_gcc_version="$(echo $Installer_gcc_rev | cut -c1)"
-
 #  Installer_update
 Installer_update () {
-  sudo apt-get update -y
+  if [ "${debian}" ]
+  then
+    sudo apt-get update -y
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf makecache --refresh
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum makecache --refresh
+      else
+        sudo apt-get update -y
+      fi
+    fi
+  fi
 }
 
 # indicates if a package is installed
 #
 # $1 - package to verify
 Installer_is_installed () {
-  hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+  if [ "${debian}" ]
+  then
+    if [ "${have_dpkg}" ]
+    then
+      hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+    else
+      if [ "${have_apt}" ]
+      then
+        hash "$1" 2>/dev/null || (apt-cache policy "$1" 2>/dev/null | grep -q "Installed")
+      else
+        hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      hash "$1" 2>/dev/null || (dnf list installed "$1" > /dev/null 2>&1)
+    else
+      if [ "${have_yum}" ]
+      then
+        hash "$1" 2>/dev/null || (yum list installed "$1" > /dev/null 2>&1)
+      else
+        hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+      fi
+    fi
+  fi
 }
 
 # install packages, used for dependencies
 #
 # $@ - list of packages to install
 Installer_install () {
-  sudo apt-get install -y $@
-  sudo apt-get clean
+  if [ "${debian}" ]
+  then
+    if [ "${have_apt}" ]
+    then
+        sudo apt-get install -y $@
+        sudo apt-get clean
+    else
+      if [ "${have_dpkg}" ]
+      then
+        sudo dpkg -i $@
+      else
+        sudo apt install $@
+        sudo apt clean
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf -y install $@
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum -y install $@
+      else
+        sudo apt install $@
+        sudo apt clean
+      fi
+    fi
+  fi
 }
 
 # remove packages, used for uninstalls
 #
 # $@ - list of packages to remove
 Installer_remove () {
-  sudo apt-get remove $@
+  if [ "${debian}" ]
+  then
+    if [ "${have_apt}" ]
+    then
+      sudo apt-get autoremove --purge $@
+    else
+      if [ "${have_dpkg}" ]
+      then
+        sudo dpkg -P $@
+      else
+        sudo apt-get autoremove --purge $@
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf autoremove $@
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum autoremove $@
+      else
+        sudo apt-get autoremove --purge $@
+      fi
+    fi
+  fi
 }
 
 ## Check Audio outpout


### PR DESCRIPTION
This pull request includes changes to support installation on RPM based Linux systems.

Let me know if these seem satisfactory or if there are better ways to accomplish these changes. Extending support for RPM based Linux systems may not seem desirable and it does require some work but I've been able to deploy MagicMirror and all the modules I use on Fedora Linux successfully after making these types of changes. The risk is, I believe, fairly low since the changes are not complicated. Still, it's your call as to whether you wish to extend support beyond `apt-get` Debian installs.

The one area of this pull request that may need tweaking is the list of RPM dependencies. My guess is that some of the packages listed in the RPM dependencies may not be required or that there may be some simpler way to express these dependencies. But, my tests were successful with these.